### PR TITLE
get optimizer and scheduler as arguments to train

### DIFF
--- a/libs/trainer/tests/test_wrapper.py
+++ b/libs/trainer/tests/test_wrapper.py
@@ -88,7 +88,14 @@ def data_fn(unique_args, get_data):
     return fn
 
 
-def test_wrapper(data_fn, preprocess, outdir, unique_args):
+@pytest.mark.parametrize(
+    "arch, arch_kwargs",
+    [
+        ("coupling", dict(num_flow_steps=10)),
+        ("coupling", dict(num_flow_steps=10, num_transform_blocks=2)),
+    ],
+)
+def test_wrapper(arch, arch_kwargs, data_fn, preprocess, outdir, unique_args):
     fn = trainify(data_fn, return_result=True)
 
     # make sure we can run the function as-is with regular arguments
@@ -103,13 +110,7 @@ def test_wrapper(data_fn, preprocess, outdir, unique_args):
 
     # call function passing keyword args
     # for train function
-    result = fn(
-        4,
-        outdir=outdir,
-        max_epochs=1,
-        arch="coupling",
-        num_flow_steps=10,
-    )
+    result = fn(4, outdir=outdir, max_epochs=1, arch=arch, **arch_kwargs)
     assert len(result["train_loss"]) == 1
 
     sys.argv = [

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -57,6 +57,8 @@ background_path = "${base.datadir}/background.h5"
 logdir = "${base.logdir}"
 outdir = "${base.basedir}/training"
 inference_params = ["frequency", "quality", "hrss", "dec", "psi", "phi"]
+optimizer = "torch.optimizers.lr_scheduler.Adam"
+optimizer_kwargs = {"weight_decay": 0}
 
 ifos = "${base.ifos}"
 


### PR DESCRIPTION
It is helpful to pass in different optimizer and scheduler names are arguments, so that they can be stored and passed from config in pyproject.toml